### PR TITLE
Add q2-boots

### DIFF
--- a/plugins/q2-boots.yml
+++ b/plugins/q2-boots.yml
@@ -1,0 +1,5 @@
+
+owner: caporaso-lab
+name: q2-boots
+branch: main
+docs: https://q2-boots.readthedocs.io/en/latest/


### PR DESCRIPTION
Add q2-boots to the list of library-plugins. This PR can serve as an example for how to add new plugins to the library.