### PR TITLE
Add q2-boots as an example

### DIFF
--- a/plugins/q2-boots.yml
+++ b/plugins/q2-boots.yml
@@ -1,0 +1,4 @@
+owner: caporaso-lab
+name: q2-boots
+branch: main
+docs: https://q2-boots.readthedocs.io/en/latest/


### PR DESCRIPTION
Adds q2-boots to the QIIME 2 Library in a single atomic commit.

This PR can be used as an example on how to add new plugins to the library.