### PR TITLE
add q2-picrust2

### DIFF
--- a/plugins/q2-picrust2.yml
+++ b/plugins/q2-picrust2.yml
@@ -1,0 +1,4 @@
+owner: picrust
+name: q2-picrust2
+branch: master
+docs: https://github.com/picrust/picrust2/wiki/q2-picrust2-Tutorial/


### PR DESCRIPTION
@R-Wright-1, does this look right to you? Mainly my question is about the documentation URL - is that the best one?

Once we merge this, q2-picrust2 will be on the new QIIME 2 Library. 