### PR TITLE
Add deeptaxa plugin

### DIFF
--- a/plugins/deeptaxa.yml
+++ b/plugins/deeptaxa.yml
@@ -1,0 +1,4 @@
+owner: systems-genomics-lab
+name: deeptaxa
+branch: main
+docs: https://systems-genomics-lab.github.io/deeptaxa/


### PR DESCRIPTION
Adds the **DeepTaxa** QIIME 2 plugin (`q2-deeptaxa`) to the Library catalog.

DeepTaxa classifies 16S rRNA sequences into all seven taxonomic ranks in one pass using a hybrid CNN-BERT model. The plugin provides `classify`, `fit`, and `describe` actions and a `DeepTaxaModel` artifact type.

- Repository: https://github.com/systems-genomics-lab/deeptaxa
- Environment file: `environment-files/deeptaxa-qiime2-amplicon-2024.10.yml` (no `name:` field; QIIME 2 amplicon 2024.10). Building the env from it and confirming the plugin registers is covered by CI in the repo.
- Distributed on PyPI and Bioconda as `deeptaxa-rrna`.
- Paper: https://doi.org/10.1093/bioadv/vbag166